### PR TITLE
Add possibility to configure strict_variables and debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/ 
+composer.lock
 
 # Created by https://www.gitignore.io/api/macos,phpstorm
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ class TwigFilesystemLoader extends BaseTwigFilesystemLoader
             return $fullFilePath;
         }
 
-        ..
+        ...
     }
 }
 ```
@@ -105,6 +105,23 @@ Load all the extensions into your `Twig_Environment` instance:
             $twig->addExtension($extension);
         }
     }
+```
+
+# `strict_variables` and `debug` config flags
+
+By default, the `strict_variables` flag of twig is set to `false` and the `debug` flag is set to true. 
+To change these variables, pass them in an optional config object with their desired values while configuring 
+fractal:
+
+```
+    const frctlTwig = require("frctl-twig");
+    
+    fractal.components.engine(frctlTwig({
+        strict_variables: true, // Or false
+        debug: false // Or true
+    }));
+    
+    // Further setup...
 ```
 
 # Credits

--- a/adapter.js
+++ b/adapter.js
@@ -7,9 +7,15 @@ const utils      = require('@frctl/fractal').utils;
 
 class TwigAdapter extends Adapter {
 
-  constructor(source, app) {
+  constructor(source, app, twigOptions) {
     super(null, source);
     this._app = app;
+
+    if (typeof twigOptions === 'undefined') {
+      twigOptions = {};
+    }
+
+    this._twigOptions = twigOptions;
   }
 
   render(path, str, context, meta) {
@@ -26,7 +32,7 @@ class TwigAdapter extends Adapter {
       partials[view.handle] = view.path;
     });
 
-    const options = {
+    var options = {
       context: context,
       aliases: partials,
       root: this._source.fullPath,
@@ -39,8 +45,10 @@ class TwigAdapter extends Adapter {
           ).replace('/file', '/')
     };
 
+    var mergedOptions = Object.assign({}, this._twigOptions, options);
+
     return new Promise(function (res, rej) {
-      twig(path, options, function (err, html) {
+      twig(path, mergedOptions, function (err, html) {
         err ? rej(err) : res(html);
       });
     });
@@ -54,11 +62,11 @@ function setEnv(key, value, context) {
   }
 }
 
-module.exports = function () {
+module.exports = function (twigOptions) {
 
   return {
     register(source, app) {
-      return new TwigAdapter(source, app);
+      return new TwigAdapter(source, app, twigOptions);
     }
   }
 

--- a/engine.js
+++ b/engine.js
@@ -1,14 +1,14 @@
 const execPHP = require('exec-php');
 const trim = require('trim');
 
-const twigOptions = {
+var twigDefaultOptions = {
   root: null,
   context: {}
 };
 
 exports.renderFile = function (entry, options, cb) {
   // Merge the global options with the local ones.
-  options = Object.assign({}, twigOptions, options);
+  options = Object.assign({}, twigDefaultOptions, options);
 
   execPHP('engine.php', null, function (error, php) {
     // Call the callback on error or the render function on success.
@@ -21,7 +21,7 @@ exports.renderFile = function (entry, options, cb) {
 
 exports.createEngine = function (options) {
   // Merge the options with default options.
-  twigOptions = Object.assign(twigOptions, options);
+  twigDefaultOptions = Object.assign(twigDefaultOptions, options);
 
   return exports.renderFile;
 };

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -67,7 +67,11 @@ class Twig
             new \Twig_Loader_Filesystem($rootDir),
         ));
 
-        $twig = new \Twig_Environment($loader, array('debug' => true));
+        $twig = new \Twig_Environment($loader, array(
+            'debug' => isset($options['debug']) ? $options['debug'] : true,
+            'strict_variables' => isset($options['strict_variables']) ? $options['strict_variables'] : false,
+        ));
+
         $twig->addExtension(new \Twig_Extension_Debug());
 
         $extensions = array();


### PR DESCRIPTION
See README.md. `strict_variables` and `debug` flags for Twig can be now configured while setting up fractal:

```
    const frctlTwig = require("frctl-twig");
    
    fractal.components.engine(frctlTwig({
        strict_variables: true, // Or false
        debug: false // Or true
    }));
    
    // Further setup...
```